### PR TITLE
Add target to run tests continuously

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ npm run dist
 # Run unit tests
 npm test
 
+# Run the unit tests continuously (repeat the test when code changes are saved)
+npm run test:watch
+
 # Lint all files in src (also automatically done AFTER tests are run)
 npm run lint
 
@@ -67,3 +70,4 @@ react-webpack-template is available under MIT-License and can therefore be used 
 
 ## Contributors
 - Weblogixx (cs@weblogixx.de)
+- Martin Jul (martin@mjul.com)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node server.js --env=dev",
     "test": "karma start",
+    "test:watch": "karma start --singleRun=false",
     "posttest": "npm run lint",
     "serve": "node server.js --env=dev",
     "serve:dist": "node server.js --env=dist",


### PR DESCRIPTION
Enables `npm run test:watch`