### PR TITLE
#4 -- added DefinePlugin to plugins for dist builds

### DIFF
--- a/cfg/dist.js
+++ b/cfg/dist.js
@@ -10,6 +10,9 @@ var config = _.merge({
   devtool: 'sourcemap',
   plugins: [
     new webpack.optimize.DedupePlugin(),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': '"production"'
+    }),
     new webpack.optimize.UglifyJsPlugin(),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.optimize.AggressiveMergingPlugin(),


### PR DESCRIPTION
This PR makes use of Webpack's `DefinePlugin` to substitute source code access to `process.env.NODE_ENV` to the string representation of `production`, which allows the uglifier to remove non-production code checks and minimizes the build size of app.js.