### PR TITLE
Don't rely Karma autoWatch being true in config

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js --env=dev",
     "test": "karma start",
-    "test:watch": "karma start --singleRun=false",
+    "test:watch": "karma start --autoWatch=true --singleRun=false",
     "posttest": "npm run lint",
     "serve": "node server.js --env=dev",
     "serve:dist": "node server.js --env=dist",


### PR DESCRIPTION
This makes sure that `npm run test:watch` works even if people change the `autoWatch` flag to `false` in the `karma.conf.js`. 