### PR TITLE
Fix override order for base.js and dev.js / dist.js

### DIFF
--- a/cfg/dev.js
+++ b/cfg/dev.js
@@ -7,7 +7,7 @@ var baseConfig = require('./base');
 // Add needed plugins here
 var BowerWebpackPlugin = require('bower-webpack-plugin');
 
-var config = _.merge({
+var config = _.merge(baseConfig, {
   entry: [
     'webpack-dev-server/client?http://127.0.0.1:8000',
     'webpack/hot/only-dev-server',
@@ -22,7 +22,7 @@ var config = _.merge({
       searchResolveModulesDirectories: false
     })
   ]
-}, baseConfig);
+});
 
 // Add needed loaders
 config.module.loaders.push({

--- a/cfg/dist.js
+++ b/cfg/dist.js
@@ -7,7 +7,7 @@ var baseConfig = require('./base');
 // Add needed plugins here
 var BowerWebpackPlugin = require('bower-webpack-plugin');
 
-var config = _.merge({
+var config = _.merge(baseConfig, {
   entry: path.join(__dirname, '../src/components/run'),
   cache: false,
   devtool: 'sourcemap',
@@ -24,7 +24,7 @@ var config = _.merge({
     new webpack.optimize.AggressiveMergingPlugin(),
     new webpack.NoErrorsPlugin()
   ]
-}, baseConfig);
+});
 
 config.module.loaders.push({
   test: /\.(js|jsx)$/,


### PR DESCRIPTION
In lodash _.merge the last entry wins, so I have moved the baseConfig to the front of the merge, so that the locally defined settings in dev.js and dist.js will have priority.