### PR TITLE
Config -- added base config object for env-independent settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "webpack-dev-server": "^1.12.0"
   },
   "dependencies": {
+    "core-js": "^1.2.6",
     "lodash": "^3.10.1",
     "normalize.css": "^3.0.3",
     "react": "^0.14.0",

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 /*eslint no-console:0 */
+require('core-js/fn/object/assign');
 var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
 var config = require('./webpack.config');

--- a/src/components/run.js
+++ b/src/components/run.js
@@ -1,3 +1,4 @@
+import 'core-js/fn/object/assign';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './Main';

--- a/src/config/base.js
+++ b/src/config/base.js
@@ -1,0 +1,6 @@
+'use strict';
+
+
+// Settings configured here will be merged into the final config object.
+export default {
+}

--- a/src/config/dev.js
+++ b/src/config/dev.js
@@ -1,7 +1,10 @@
 'use strict';
 
-const config = {
+import baseConfig from './base';
+
+
+let config = {
   appEnv: 'dev'  // feel free to remove the appEnv property here
 };
 
-export default config;
+export default Object.freeze(Object.assign({}, baseConfig, config));

--- a/src/config/dist.js
+++ b/src/config/dist.js
@@ -1,7 +1,11 @@
 'use strict';
 
-const config = {
+import baseConfig from './base';
+
+
+let config = {
   appEnv: 'dist'  // feel free to remove the appEnv property here
 };
 
-export default config;
+export default Object.freeze(Object.assign({}, baseConfig, config));
+

--- a/src/config/test.js
+++ b/src/config/test.js
@@ -1,7 +1,11 @@
 'use strict';
 
-const config = {
+import baseConfig from './base';
+
+
+let config = {
   appEnv: 'test'  // don't remove the appEnv property here
 };
 
-export default config;
+export default Object.freeze(Object.assign(baseConfig, config));
+

--- a/test/loadtests.js
+++ b/test/loadtests.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('core-js/fn/object/assign');
+
 // Add support for all files in the test directory
 const testsContext = require.context('.', true, /(Test\.js$)|(Helper\.js$)/);
 testsContext.keys().forEach(testsContext);


### PR DESCRIPTION
This PR updates the app environment configuration. It adds a `base.js` that may contain env-independent settings. The environment-specific config files (`dev.js`, `test.js` and `dist.js`) merge the base settings, so that the config object imported with `import config form 'config';` contains base and env-settings. If settings are defined in the base and env-object, the env object's value takes precedence. Merging utilizes ES2015 `Object.assign()` which is polyfilled with core-js. The config object returned by the import is now frozen to prevent mutation.