### PR TITLE
feat: add sass and scss file resolve

### DIFF
--- a/cfg/base.js
+++ b/cfg/base.js
@@ -21,7 +21,7 @@ module.exports = {
     noInfo: false
   },
   resolve: {
-    extensions: ['', '.js', '.jsx'],
+    extensions: ['', '.js', '.jsx', '.scss', '.sass'],
     alias: {
       actions: srcPath + '/actions/',
       components: srcPath + '/components/',


### PR DESCRIPTION
import react-toolbox error. Because it introduces scss files.

```
Module not found: Error: Cannot resolve 'file' or 'directory' ./style in /Users/react/react-example/node_modules/react-toolbox/lib/button
```