### PR TITLE
fix eslint-loader path error

### DIFF
--- a/cfg/base.js
+++ b/cfg/base.js
@@ -35,7 +35,7 @@ module.exports = {
     preLoaders: [
       {
         test: /\.(js|jsx)$/,
-        include: path.join(__dirname, 'src'),
+        include: srcPath,
         loader: 'eslint-loader'
       }
     ],


### PR DESCRIPTION
Now the webpack eslint not work.
The path must be `path.join(__dirname, '/../src')`,  not `path.join(__dirname, 'src')`.