### PR TITLE
Move core-js, lodash and react-addons-test-utils to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "bower-webpack-plugin": "^0.1.9",
     "chai": "^3.2.0",
     "copyfiles": "^0.2.1",
-    "core-js": "^1.2.6",
     "css-loader": "^0.23.0",
     "eslint": "^1.2.1",
     "eslint-loader": "^1.0.0",
@@ -76,6 +75,7 @@
     "webpack-dev-server": "^1.12.0"
   },
   "dependencies": {
+    "core-js": "^1.2.6",
     "normalize.css": "^3.0.3",
     "react": "^0.14.0",
     "react-dom": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "bower-webpack-plugin": "^0.1.9",
     "chai": "^3.2.0",
     "copyfiles": "^0.2.1",
+    "core-js": "^1.2.6",
     "css-loader": "^0.23.0",
     "eslint": "^1.2.1",
     "eslint-loader": "^1.0.0",
@@ -60,11 +61,13 @@
     "karma-phantomjs-shim": "^1.1.1",
     "karma-sourcemap-loader": "^0.3.5",
     "karma-webpack": "^1.7.0",
+    "lodash": "^3.10.1",
     "minimist": "^1.2.0",
     "mocha": "^2.2.5",
     "null-loader": "^0.1.1",
     "open": "0.0.5",
     "phantomjs": "^1.9.18",
+    "react-addons-test-utils": "^0.14.0",
     "react-hot-loader": "^1.2.9",
     "rimraf": "^2.4.3",
     "style-loader": "^0.13.0",
@@ -73,11 +76,8 @@
     "webpack-dev-server": "^1.12.0"
   },
   "dependencies": {
-    "core-js": "^1.2.6",
-    "lodash": "^3.10.1",
     "normalize.css": "^3.0.3",
     "react": "^0.14.0",
-    "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0"
   }
 }


### PR DESCRIPTION
This moves `core-js`, `lodash` and `react-addons-test-utils`  dependencies in package.json to devDependencies. 

This is to keep the dependencies to the front-end code dependencies and make sure anything that is used just for build/test purposes is specified under devDependencies.