### PR TITLE
PhantomJS Promise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,4 @@ react-webpack-template is available under MIT-License and can therefore be used 
 - Martin Jul (martin@mjul.com)
 - Stephan Herzog (sthzgvie@gmail.com)
 - Kashif Iqbal Khan
+- Ignat Shining (mail@igonato.com)

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,6 +5,7 @@ module.exports = function(config) {
     basePath: '',
     browsers: [ 'PhantomJS' ],
     files: [
+      'node_modules/babel-polyfill/dist/polyfill.js',
       'test/loadtests.js'
     ],
     port: 8080,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,7 +5,6 @@ module.exports = function(config) {
     basePath: '',
     browsers: [ 'PhantomJS' ],
     files: [
-      'node_modules/babel-polyfill/dist/polyfill.js',
       'test/loadtests.js'
     ],
     port: 8080,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-core": "^6.0.0",
     "babel-eslint": "^5.0.0-beta4",
     "babel-loader": "^6.0.0",
+    "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.0.15",
     "babel-preset-react": "^6.0.15",
     "bower-webpack-plugin": "^0.1.9",

--- a/test/loadtests.js
+++ b/test/loadtests.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('babel-polyfill');
 require('core-js/fn/object/assign');
 
 // Add support for all files in the test directory


### PR DESCRIPTION
Hi there. As of today, PhantomJS doesn't support Promise. Test:

```js
  ...

  it('should support Promise', (done) => {
    var p = new Promise(resolve => setTimeout(() => resolve(true), 100));
    p.then(() => done());
  });
```
fails with `Can't find variable: Promise` error. Can be fixed by installing babel-polyfill module and including `node_modules/babel-polyfill/dist/polyfill.js` in the files section in karma.conf.js.