### PR TITLE
Pin eslint version to avoid broken dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chai": "^3.2.0",
     "copyfiles": "^0.2.1",
     "css-loader": "^0.23.0",
-    "eslint": "^2.0.0",
+    "eslint": "2.2.0",
     "eslint-loader": "^1.0.0",
     "eslint-plugin-react": "^4.0.0",
     "file-loader": "^0.8.4",


### PR DESCRIPTION
[eslint](https://github.com/eslint/eslint/issues/5476) is having a missing dependency issue with their 2.3.0 release.  It may be worth pinning this eslint version for now.  Currently, this template, and also your Yeoman generator, are both not functioning out of the box.