### PR TITLE
Lingering var in config file

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const args = require('minimist')(process.argv.slice(2));
 const allowedEnvs = ['dev', 'dist', 'test'];
 
 // Set the correct environment
-var env;
+let env;
 if (args._.length > 0 && args._.indexOf('start') !== -1) {
   env = 'test';
 } else if (args.env) {


### PR DESCRIPTION
There was a lingering `var` while throughout the webpack.config.js you use es2015 syntax.

Was just browsing thru your webpack.config file and found this =)